### PR TITLE
Remove obsolete Alternative instance

### DIFF
--- a/monad-logger-extras.cabal
+++ b/monad-logger-extras.cabal
@@ -34,7 +34,7 @@ library
     , base           >=4.12   && <5
     , bytestring     >=0.10   && <0.12
     , hsyslog        >=5      && <5.1
-    , monad-logger   >=0.3.36 && <0.4
+    , monad-logger   >=0.3.40 && <0.4
     , mtl            >=2.2    && <2.3
 
   hs-source-dirs:   src

--- a/src/Control/Monad/Logger/Orphans.hs
+++ b/src/Control/Monad/Logger/Orphans.hs
@@ -8,10 +8,5 @@ import Control.Monad.Logger
 
 import Control.Applicative (Alternative(..))
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Trans (lift)
-
-instance (Monad m, Alternative m) => Alternative (LoggingT m) where
-  empty = lift empty
-  a <|> b = LoggingT $ \f -> runLoggingT a f <|> runLoggingT b f
 
 instance (Monad m, Alternative m) => MonadPlus (LoggingT m)


### PR DESCRIPTION
Upstream now implements an Alternative instance, so we don’t need the Orphan anymore
